### PR TITLE
Add reporting layer CLI utility and updated configuration for analytics database

### DIFF
--- a/create_analytics_db.py
+++ b/create_analytics_db.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""CLI utility for constructing the DuckDB reporting layer."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Any
+
+from powerview.src.config import load_metering_points
+from powerview.src.reporting import build_reporting_layer
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the reporting-layer builder."""
+
+    parser = argparse.ArgumentParser(description="Create or refresh the analytics DuckDB")
+    parser.add_argument(
+        "--data-path",
+        dest="data_path",
+        help="Optional override for the Parquet data directory",
+    )
+    parser.add_argument(
+        "--analytics-db",
+        dest="analytics_db_path",
+        help="Optional override for the analytics DuckDB path",
+    )
+    parser.add_argument(
+        "--metering-points-file",
+        dest="metering_points_file",
+        help="Explicit path to a metering_points.yml file",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point for the CLI utility."""
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    args = _parse_args()
+    metadata_override: dict[str, dict[str, Any]] | None = None
+    if args.metering_points_file:
+        metadata_override = load_metering_points(args.metering_points_file)
+
+    build_reporting_layer(
+        data_path=args.data_path,
+        analytics_db_path=args.analytics_db_path,
+        metering_points_override=metadata_override,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/powerview/src/config.py
+++ b/powerview/src/config.py
@@ -137,7 +137,7 @@ def load_config() -> dict:
         "metering_points": metering_points,
         "metering_point_ids": dict(metering_point_ids),
         "data_storage_path": os.getenv("DATA_STORAGE_PATH", "./data"),
-        # TODO add analytics database path
+        "analytics_db_path": os.getenv("ANALYTICS_DB_PATH", "./duckdb/analytics.duckdb"),
         "state_db_path": os.getenv("STATE_DB_PATH", "./state.duckdb"),
         "log_level": os.getenv("LOG_LEVEL", "INFO"),
         "initial_backfill_days": int(os.getenv("INITIAL_BACKFILL_DAYS", "1095")),

--- a/powerview/src/metadata.py
+++ b/powerview/src/metadata.py
@@ -1,0 +1,91 @@
+"""Utilities for loading metering-point metadata into DuckDB."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import pandas as pd
+
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+_CORE_METADATA_FIELDS = {"id", "name", "type", "location", "description"}
+
+
+def build_metadata_frame(metering_points: dict[str, dict[str, Any]]) -> pd.DataFrame:
+    """Convert metering-point metadata into a normalized pandas DataFrame.
+
+    Args:
+        metering_points: Mapping of metering point IDs to metadata dictionaries.
+
+    Returns:
+        pandas.DataFrame: Normalized metadata ready for DuckDB ingestion.
+    """
+
+    records: list[dict[str, Any]] = []
+    for meter_id, metadata in sorted(metering_points.items()):
+        normalized = metadata or {}
+        extras = {
+            key: value for key, value in normalized.items() if key not in _CORE_METADATA_FIELDS
+        }
+        records.append(
+            {
+                "metering_point_id": meter_id,
+                "name": normalized.get("name", meter_id),
+                "type": normalized.get("type"),
+                "location": normalized.get("location"),
+                "description": normalized.get("description"),
+                "extra_metadata": json.dumps(extras, ensure_ascii=True) if extras else None,
+            }
+        )
+
+    if not records:
+        return pd.DataFrame(
+            columns=[
+                "metering_point_id",
+                "name",
+                "type",
+                "location",
+                "description",
+                "extra_metadata",
+            ]
+        )
+
+    return pd.DataFrame.from_records(records)
+
+
+def load_metadata_table(
+    connection: duckdb.DuckDBPyConnection,
+    metering_points: dict[str, dict[str, Any]],
+    table_name: str = "reporting.meter_metadata",
+) -> None:
+    """Create or replace the DuckDB metadata table from YAML-derived data.
+
+    Args:
+        connection: Active DuckDB connection for the analytics database.
+        metering_points: Mapping of metering point IDs to metadata dictionaries.
+        table_name: Fully qualified table name to create/replace.
+    """
+
+    metadata_frame = build_metadata_frame(metering_points)
+    connection.execute("CREATE SCHEMA IF NOT EXISTS reporting")
+
+    connection.register("meter_metadata_df", metadata_frame)
+    try:
+        connection.execute(
+            f"""
+            CREATE OR REPLACE TABLE {table_name} AS
+            SELECT * FROM meter_metadata_df
+            """
+        )
+    finally:
+        connection.unregister("meter_metadata_df")
+
+    logger.info(
+        "Loaded %d metering-point metadata row(s) into %s",
+        len(metadata_frame.index),
+        table_name,
+    )

--- a/powerview/src/reporting.py
+++ b/powerview/src/reporting.py
@@ -1,0 +1,280 @@
+"""Reporting layer builder for analytics DuckDB."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import duckdb
+from powerview.src.config import load_config
+from powerview.src.metadata import load_metadata_table
+
+logger = logging.getLogger(__name__)
+
+
+def _escape_literal(value: str) -> str:
+    """Escape single quotes for safe SQL embedding."""
+
+    return value.replace("'", "''")
+
+
+def _parquet_glob(base_path: Path) -> tuple[str, list[Path]]:
+    """Return the parquet glob string and the files that match it."""
+
+    pattern = base_path / "metering_point=*/date=*/consumption_data.parquet"
+    files = sorted(base_path.glob("metering_point=*/date=*/consumption_data.parquet"))
+    if not files:
+        raise FileNotFoundError(
+            f"No Parquet files found under {base_path}. Run the extraction pipeline first."
+        )
+    return pattern.as_posix(), files
+
+
+def _view_statements(parquet_glob: str) -> list[tuple[str, str]]:
+    """Assemble SQL statements required for the reporting layer."""
+
+    escaped_glob = _escape_literal(parquet_glob)
+    statements = [
+        (
+            "reporting.meter_data_stage",
+            f"""
+            CREATE OR REPLACE VIEW reporting.meter_data_stage AS
+            WITH source AS (
+                SELECT
+                    metering_point_id,
+                    timezone('UTC', timestamp) AS reading_ts_utc,
+                    consumption_value,
+                    quality,
+                    unit,
+                    ingestion_timestamp,
+                    ingestion_date
+                FROM read_parquet('{escaped_glob}')
+            )
+            SELECT
+                metering_point_id,
+                reading_ts_utc,
+                DATE(reading_ts_utc) AS reading_date,
+                EXTRACT('hour' FROM reading_ts_utc) AS reading_hour,
+                EXTRACT('isodow' FROM reading_ts_utc) AS reading_weekday,
+                strftime(reading_ts_utc, '%A') AS reading_weekday_label,
+                EXTRACT('month' FROM reading_ts_utc) AS reading_month,
+                EXTRACT('year' FROM reading_ts_utc) AS reading_year,
+                consumption_value,
+                quality,
+                unit,
+                ingestion_timestamp,
+                ingestion_date
+            FROM source;
+            """,
+        ),
+        (
+            "reporting.meter_data_clean",
+            """
+            CREATE OR REPLACE VIEW reporting.meter_data_clean AS
+            SELECT *
+            FROM reporting.meter_data_stage
+            WHERE consumption_value IS NOT NULL AND consumption_value >= 0;
+            """,
+        ),
+        (
+            "reporting.daily_consumption",
+            """
+            CREATE OR REPLACE VIEW reporting.daily_consumption AS
+            SELECT
+                metering_point_id,
+                reading_date,
+                SUM(consumption_value) AS total_kwh,
+                AVG(consumption_value) AS avg_kwh,
+                MIN(consumption_value) AS min_kwh,
+                MAX(consumption_value) AS max_kwh,
+                COUNT(*) AS reading_count
+            FROM reporting.meter_data_clean
+            GROUP BY metering_point_id, reading_date;
+            """,
+        ),
+        (
+            "reporting.monthly_consumption",
+            """
+            CREATE OR REPLACE VIEW reporting.monthly_consumption AS
+            WITH monthly AS (
+                SELECT
+                    metering_point_id,
+                    CAST(DATE_TRUNC('month', reading_date) AS DATE) AS month_start,
+                    SUM(consumption_value) AS total_kwh
+                FROM reporting.meter_data_clean
+                GROUP BY metering_point_id, month_start
+            ),
+            enriched AS (
+                SELECT
+                    metering_point_id,
+                    month_start,
+                    total_kwh,
+                    LAG(total_kwh) OVER (
+                        PARTITION BY metering_point_id
+                        ORDER BY month_start
+                    ) AS previous_month_kwh
+                FROM monthly
+            )
+            SELECT
+                metering_point_id,
+                month_start,
+                total_kwh,
+                previous_month_kwh,
+                total_kwh - previous_month_kwh AS delta_kwh,
+                CASE
+                    WHEN previous_month_kwh IS NULL OR previous_month_kwh = 0 THEN NULL
+                    ELSE (total_kwh - previous_month_kwh) / previous_month_kwh
+                END AS delta_ratio
+            FROM enriched;
+            """,
+        ),
+        (
+            "reporting.hourly_profile",
+            """
+            CREATE OR REPLACE VIEW reporting.hourly_profile AS
+            SELECT
+                metering_point_id,
+                reading_hour,
+                reading_weekday,
+                reading_weekday_label,
+                AVG(consumption_value) AS avg_kwh
+            FROM reporting.meter_data_clean
+            GROUP BY metering_point_id, reading_hour, reading_weekday, reading_weekday_label;
+            """,
+        ),
+        (
+            "reporting.missing_data_summary",
+            """
+            CREATE OR REPLACE VIEW reporting.missing_data_summary AS
+            WITH daily_counts AS (
+                SELECT
+                    metering_point_id,
+                    reading_date,
+                    COUNT(*) AS actual_readings
+                FROM reporting.meter_data_stage
+                GROUP BY metering_point_id, reading_date
+            )
+            SELECT
+                metering_point_id,
+                reading_date,
+                actual_readings,
+                24 AS expected_readings,
+                24 - actual_readings AS missing_readings
+            FROM daily_counts;
+            """,
+        ),
+        (
+            "reporting.load_variability",
+            """
+            CREATE OR REPLACE VIEW reporting.load_variability AS
+            SELECT
+                metering_point_id,
+                reading_date,
+                STDDEV_POP(consumption_value) AS hourly_stddev_kwh,
+                MAX(consumption_value) AS peak_kwh
+            FROM reporting.meter_data_clean
+            GROUP BY metering_point_id, reading_date;
+            """,
+        ),
+        (
+            "reporting.daily_quality_flags",
+            """
+            CREATE OR REPLACE VIEW reporting.daily_quality_flags AS
+            WITH enriched AS (
+                SELECT
+                    dc.metering_point_id,
+                    dc.reading_date,
+                    dc.total_kwh,
+                    LAG(dc.total_kwh) OVER (
+                        PARTITION BY dc.metering_point_id
+                        ORDER BY dc.reading_date
+                    ) AS previous_total,
+                    LEAD(dc.total_kwh) OVER (
+                        PARTITION BY dc.metering_point_id
+                        ORDER BY dc.reading_date
+                    ) AS next_total
+                FROM reporting.daily_consumption AS dc
+            )
+            SELECT
+                metering_point_id,
+                reading_date,
+                total_kwh,
+                CASE
+                    WHEN total_kwh = 0
+                        AND COALESCE(previous_total, 0) > 0
+                        AND COALESCE(next_total, 0) > 0 THEN TRUE
+                    ELSE FALSE
+                END AS isolated_zero_flag
+            FROM enriched;
+            """,
+        ),
+    ]
+    return statements
+
+
+_METADATA_ENRICHED_VIEW = """
+CREATE OR REPLACE VIEW reporting.meter_metadata_enriched AS
+SELECT
+    dc.metering_point_id,
+    meta.name,
+    meta.type,
+    meta.location,
+    meta.description,
+    meta.extra_metadata,
+    dc.reading_date,
+    dc.total_kwh,
+    dc.avg_kwh,
+    dc.min_kwh,
+    dc.max_kwh,
+    dc.reading_count
+FROM reporting.daily_consumption AS dc
+LEFT JOIN reporting.meter_metadata AS meta
+    ON meta.metering_point_id = dc.metering_point_id;
+"""
+
+
+def build_reporting_layer(
+    *,
+    data_path: str | Path | None = None,
+    analytics_db_path: str | Path | None = None,
+    metering_points_override: dict[str, dict[str, Any]] | None = None,
+) -> Path:
+    """Build or refresh the DuckDB reporting layer defined in the plan.
+
+    Args:
+        data_path: Optional override for the Parquet data root.
+        analytics_db_path: Optional override for the DuckDB database location.
+        metering_points_override: Optional metadata mapping to bypass config loading.
+
+    Returns:
+        Path: Location of the analytics DuckDB file.
+    """
+
+    config = load_config()
+    resolved_data_path = Path(data_path or config["data_storage_path"]).resolve()
+    resolved_analytics_path = Path(analytics_db_path or config["analytics_db_path"]).resolve()
+    metadata = metering_points_override or config["metering_points"]
+
+    if not resolved_data_path.exists():
+        raise FileNotFoundError(f"Data path does not exist: {resolved_data_path}")
+
+    resolved_analytics_path.parent.mkdir(parents=True, exist_ok=True)
+    parquet_glob, files = _parquet_glob(resolved_data_path)
+    logger.info("Found %d parquet partition(s) for reporting", len(files))
+
+    connection = duckdb.connect(resolved_analytics_path.as_posix())
+    try:
+        connection.execute("CREATE SCHEMA IF NOT EXISTS reporting")
+        for view_name, statement in _view_statements(parquet_glob):
+            connection.execute(statement)
+            logger.info("Created or replaced view %s", view_name)
+
+        load_metadata_table(connection, metadata)
+        connection.execute(_METADATA_ENRICHED_VIEW)
+        logger.info("Created metadata-enriched daily view")
+    finally:
+        connection.close()
+
+    logger.info("Reporting layer refreshed at %s", resolved_analytics_path)
+    return resolved_analytics_path

--- a/powerview/tests/test_metadata.py
+++ b/powerview/tests/test_metadata.py
@@ -1,0 +1,49 @@
+"""Tests for metadata utilities."""
+
+import json
+
+import duckdb
+from powerview.src.metadata import build_metadata_frame, load_metadata_table
+
+
+def test_build_metadata_frame_handles_extra_fields():
+    """Ensure arbitrary metadata fields are preserved as JSON."""
+
+    metering_points = {
+        "meter_001": {
+            "name": "Solar",
+            "type": "production",
+            "location": "Home",
+            "custom": "value",
+        }
+    }
+
+    frame = build_metadata_frame(metering_points)
+
+    assert frame.loc[0, "metering_point_id"] == "meter_001"
+    assert frame.loc[0, "name"] == "Solar"
+    assert json.loads(frame.loc[0, "extra_metadata"]) == {"custom": "value"}
+
+
+def test_load_metadata_table_creates_table(tmp_path):
+    """Verify DuckDB table creation from metadata DataFrame."""
+
+    metering_points = {
+        "meter_001": {
+            "name": "Solar",
+            "type": "production",
+            "location": "Home",
+        }
+    }
+
+    db_path = tmp_path / "metadata.duckdb"
+    connection = duckdb.connect(str(db_path))
+    try:
+        load_metadata_table(connection, metering_points)
+        rows = connection.execute(
+            "SELECT metering_point_id, name FROM reporting.meter_metadata"
+        ).fetchall()
+    finally:
+        connection.close()
+
+    assert rows == [("meter_001", "Solar")]

--- a/powerview/tests/test_reporting.py
+++ b/powerview/tests/test_reporting.py
@@ -1,0 +1,97 @@
+"""Integration tests for the reporting-layer builder."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pandas as pd
+import pytest
+
+import duckdb
+from powerview.src.reporting import build_reporting_layer
+
+
+def _write_sample_parquet(base_dir):
+    base_ts = datetime(2025, 1, 1, 0, 0, tzinfo=UTC)
+    records = []
+    for hour in range(24):
+        records.append(
+            {
+                "metering_point_id": "meter_001",
+                "timestamp": base_ts + timedelta(hours=hour),
+                "consumption_value": float(hour + 1),
+                "quality": "A",
+                "unit": "kWh",
+                "ingestion_timestamp": base_ts,
+                "ingestion_date": base_ts.date(),
+            }
+        )
+
+    df = pd.DataFrame.from_records(records)
+    partition_path = base_dir / "metering_point=meter_001" / "date=2025-01-01"
+    partition_path.mkdir(parents=True, exist_ok=True)
+    file_path = partition_path / "consumption_data.parquet"
+    df.to_parquet(file_path, engine="pyarrow", index=False)
+    return file_path
+
+
+def test_build_reporting_layer_creates_views(tmp_path, monkeypatch):
+    """Ensure the builder wires Parquet data into analytics views."""
+
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    _write_sample_parquet(data_root)
+    analytics_path = tmp_path / "duckdb" / "analytics.duckdb"
+
+    config = {
+        "data_storage_path": data_root,
+        "analytics_db_path": analytics_path,
+        "metering_points": {
+            "meter_001": {
+                "id": "meter_001",
+                "name": "Solar",
+                "type": "production",
+                "location": "Home",
+                "description": "Test meter",
+            }
+        },
+    }
+
+    monkeypatch.setattr("powerview.src.reporting.load_config", lambda: config)
+
+    build_reporting_layer()
+
+    connection = duckdb.connect(analytics_path.as_posix())
+    try:
+        total_kwh = connection.execute(
+            "SELECT SUM(total_kwh) FROM reporting.daily_consumption"
+        ).fetchone()[0]
+        assert total_kwh == sum(range(1, 25))
+
+        metadata_rows = connection.execute(
+            "SELECT DISTINCT name FROM reporting.meter_metadata_enriched"
+        ).fetchall()
+        assert metadata_rows == [("Solar",)]
+
+        missing_row = connection.execute(
+            "SELECT missing_readings FROM reporting.missing_data_summary"
+        ).fetchone()[0]
+        assert missing_row == 0
+    finally:
+        connection.close()
+
+
+def test_build_reporting_layer_missing_data_path(tmp_path, monkeypatch):
+    """Builder should fail fast when the data directory is absent."""
+
+    analytics_path = tmp_path / "duckdb" / "analytics.duckdb"
+    config = {
+        "data_storage_path": tmp_path / "missing-data",
+        "analytics_db_path": analytics_path,
+        "metering_points": {"meter_001": {"id": "meter_001", "name": "Solar"}},
+    }
+
+    monkeypatch.setattr("powerview.src.reporting.load_config", lambda: config)
+
+    with pytest.raises(FileNotFoundError):
+        build_reporting_layer()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "requests (>=2.32.5,<3.0.0)",
     "dotenv (>=0.9.9,<0.10.0)",
     "duckdb (>=1.4.2,<2.0.0)",
-    "pyarrow (>=22.0.0,<23.0.0)"
+    "pyarrow (>=22.0.0,<23.0.0)",
+    "pyyaml (>=6.0.2,<7.0.0)"
 ]
 
 [project.urls]

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -2,6 +2,6 @@ FROM apache/superset:latest
 
 USER root
 
-RUN uv pip install duckdb duckdb-engine pillow
+RUN uv pip install duckdb duckdb-engine pillow prophet
 
 USER superset

--- a/superset/docker-compose.yml
+++ b/superset/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - superset_data:/app/superset_home
       - ../data:/app/external_data # Change according to setting in the .env file
       - ../duckdb:/app/duckdb # Change according to setting in the .env file
+      - ../../powerview:/app/powerview # Mount the powerview code for development
     environment:
       - SUPERSET_LOAD_EXAMPLES=no
       - DATABASE_DB=superset


### PR DESCRIPTION
- create_analytics_db.py for building the DuckDB reporting layer via CLI.
- Updated config.py to include analytics database path.
- Added metadata.py for loading metering-point metadata into DuckDB.
- Implemented reporting.py to build the reporting layer with necessary views.
- Modified Dockerfile to install prophet package.
- Updated docker-compose.yml to mount powerview code for development.