### PR TITLE
Closes #11 extend configuration for price areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone sunefibaek/powerview
 ```
 #### Initial Setup
 Copy .env.example to .env and insert your API key from Eloverblik. The key can be created by signing in with MitID and generating a key.\
-Copy the file metering_points.yml.example to metering_points.yml and insert the required metering point IDs in the file. Fill in `name`, `type`, `location`, and `description`. These fields are not used directly but are made available in the reporting layer.
+Copy the file metering_points.yml.example to metering_points.yml and insert the required metering point IDs in the file. Fill in `name`, `type`, `location`, `description`, and `price_area` (`DK1` - which covers Jutland and Funen -  or `DK2` - covering Sealand, Lolland-falster, Møn, and Bornholm). These fields are not used directly in ingestion but are made available in the reporting layer.
 #### Backfill
 The first run is used for back filling data. The amount of data fetched initially is defaulted to 90 days. The value can be changed in `.env` in the `INITIAL_BACKFILL_DAYS=90` parameter. The API has a cap of 730 days.\
 The run might take a fair bit of time depending on the amount of days.

--- a/docs/initial-setup.md
+++ b/docs/initial-setup.md
@@ -33,6 +33,20 @@ cp metering_points.yml.example metering_points.yml
 
 Fill in `name`, `type`, `location`, and `description`. These fields are used for labeling in the reporting layer.
 
+The Danish energy market is separated into two independant bidding zones or price areas: DK1 (West) and DK2 (East). Set `price_area` to `DK1` or `DK2` for each metering point depending on the location they are in. `DK1` covers Jutland and Funen. `DK2` covers Sealand, Lolland-falster, Møn, and Bornholm.
+
+Example:
+
+```yaml
+metering_points:
+	"123234345":
+		name: Home Consumption
+		type: consumption
+		location: Home
+		description: Main household consumption
+		price_area: DK1
+```
+
 ## 3) Install dependencies
 
 The project uses Poetry:

--- a/metering_points.yml.example
+++ b/metering_points.yml.example
@@ -4,15 +4,18 @@ metering_points:
     type: production
     location: Home
     description: Electricity delivered to grid from solar panels
+    price_area: DK1
 
   "234345456":
     name: Grid Import
     type: consumption
     location: Home
     description: Electricity consumed from grid
+    price_area: DK1
 
   "345456567":
     name: Home Total
     type: consumption
     location: Home
     description: Total household consumption
+    price_area: DK1


### PR DESCRIPTION
This pull request introduces explicit support for the `price_area` attribute for metering points, ensuring that each metering point is associated with a valid Danish energy price zone (`DK1` or `DK2`). The changes update documentation, configuration handling, and test coverage to enforce and clarify this requirement.

**Documentation updates:**

* Added explanations and examples for the `price_area` field in both `README.md` and `docs/initial-setup.md`, clarifying its purpose and valid values (`DK1` and `DK2`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14) [[2]](diffhunk://#diff-0723a8c264ba12a075ce276d0bd85eb278a6d3606de5fbda5cb08dfb1b93cf11R36-R49)
* Updated `metering_points.yml.example` to include `price_area` for all sample entries.

**Configuration logic:**

* Introduced `VALID_PRICE_AREAS` in `powerview/src/config.py`, and updated `load_metering_points` to validate `price_area`. If missing, defaults to `DK1`; if invalid, raises a `ValueError`. [[1]](diffhunk://#diff-ce03907591864243875f7da0192bab4083bfb37619c9a9b764da007cc177f48fR14) [[2]](diffhunk://#diff-ce03907591864243875f7da0192bab4083bfb37619c9a9b764da007cc177f48fL108-R131)

**Test coverage improvements:**

* Extended tests in `powerview/tests/test_config.py` to check for correct handling of `price_area`, including defaulting, validation, and error cases. [[1]](diffhunk://#diff-fedcefa868b5191de1466b7e37196fabf49db745992ac26238e964729920660cR35) [[2]](diffhunk://#diff-fedcefa868b5191de1466b7e37196fabf49db745992ac26238e964729920660cR47) [[3]](diffhunk://#diff-fedcefa868b5191de1466b7e37196fabf49db745992ac26238e964729920660cR61) [[4]](diffhunk://#diff-fedcefa868b5191de1466b7e37196fabf49db745992ac26238e964729920660cR100-R103) [[5]](diffhunk://#diff-fedcefa868b5191de1466b7e37196fabf49db745992ac26238e964729920660cL126-R132) [[6]](diffhunk://#diff-fedcefa868b5191de1466b7e37196fabf49db745992ac26238e964729920660cR156) [[7]](diffhunk://#diff-fedcefa868b5191de1466b7e37196fabf49db745992ac26238e964729920660cR166-R196)